### PR TITLE
new file format, automated build, code quality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM golang:alpine as builder
-RUN apk add --no-cache make git
+RUN apk add --no-cache make git upx
 
 WORKDIR /go/src/github.com/MaZderMind/traefik-certificate-extractor
 COPY . .
 
-RUN make binary
+RUN make binary \
+    && upx --ultra-brute traefik-certificate-extractor
 
 FROM scratch
 COPY --from=builder /go/src/github.com/MaZderMind/traefik-certificate-extractor/traefik-certificate-extractor /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
+FROM golang:alpine as builder
+RUN apk add --no-cache make git
+
+WORKDIR /go/src/github.com/MaZderMind/traefik-certificate-extractor
+COPY . .
+
+RUN make binary
+
 FROM scratch
-ADD traefik-certificate-extractor /
+COPY --from=builder /go/src/github.com/MaZderMind/traefik-certificate-extractor/traefik-certificate-extractor /
 
 VOLUME /var/acmejson
 CMD ["/traefik-certificate-extractor", "-acmejson=/var/acmejson/acme.json", "-target=/var/acmejson/certs/", "-watch"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,5 @@ FROM scratch
 COPY --from=builder /go/src/github.com/MaZderMind/traefik-certificate-extractor/traefik-certificate-extractor /
 
 VOLUME /var/acmejson
-CMD ["/traefik-certificate-extractor", "-acmejson=/var/acmejson/acme.json", "-target=/var/acmejson/certs/", "-watch"]
+ENTRYPOINT ["/traefik-certificate-extractor"]
+CMD ["-acmejson=/var/acmejson/acme.json", "-target=/var/acmejson/certs/", "-watch"]

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2017-2018 Peter Körner <peter@mazdermind.de>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,7 @@ run:
 	go run ${GOFILES}
 
 traefik-certificate-extractor: ${GOFILES}
-	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o traefik-certificate-extractor .
-	strip traefik-certificate-extractor
+	CGO_ENABLED=0 GOOS=linux go build -a -ldflags="-s -w" -installsuffix cgo -o traefik-certificate-extractor .
 
 container: binary
 	docker build -t mazdermind/traefik-certificate-extractor:latest .

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,18 @@
-.PHONY: default binary run container push
+.PHONY: default dependencies binary run container
 
 GOFILES=traefik-certificate-extractor.go model.go
 
 default: binary
 binary: traefik-certificate-extractor
 
-run:
+dependencies:
+	go get
+
+run: dependencies
 	go run ${GOFILES}
 
-traefik-certificate-extractor: ${GOFILES}
+traefik-certificate-extractor: ${GOFILES} dependencies
 	CGO_ENABLED=0 GOOS=linux go build -a -ldflags="-s -w" -installsuffix cgo -o traefik-certificate-extractor .
 
-container: binary
+container:
 	docker build -t mazdermind/traefik-certificate-extractor:latest .
-
-push: container
-	docker push mazdermind/traefik-certificate-extractor:latest

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ For each domain and it extracts
  - `fullchain` (cert + intermediate)
  - `privkey` (private key)
  - `all` (private key + cert + intermediate)
- - `url` (url of the certificate at the CA)
 
 For SANs it creates symlinks to the main domain's files.
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ traefik-certificate-extractor
 
 A small utility which monitors a traefik-managed acme.json and extracts the plain certificate-files from it.
 
+This is a fork based on the [excelent work of MaZderMind](https://github.com/MaZderMind/traefik-certificate-extractor).
+
 For each domain and it extracts
  - `fullchain` (cert + intermediate)
  - `privkey` (private key)
@@ -25,6 +27,6 @@ Usage of ./traefik-certificate-extractor:
 
 Docker-Container
 ----------------
-https://hub.docker.com/r/mazdermind/traefik-certificate-extractor/
+[sbruder/traefik-certificate-extractor](https://hub.docker.com/r/sbruder/traefik-certificate-extractor/)
 
 Expects `acme.json` in `/var/acmejson/acme.json`, writes certs to `/var/acmejson/certs/`

--- a/model.go
+++ b/model.go
@@ -8,9 +8,9 @@ type Domain struct {
 
 // Certificate is used to store certificate info
 type Certificate struct {
-	Domain        Domain
-	Certificate   []byte
-	Key           []byte
+	Domain      Domain
+	Certificate []byte
+	Key         []byte
 }
 
 // Certificates holds one or more certificates

--- a/model.go
+++ b/model.go
@@ -1,26 +1,5 @@
 package main
 
-// Account is used to store lets encrypt registration info
-type Account struct {
-	//Email              string
-	//Registration       *acme.RegistrationResource
-	//PrivateKey         []byte
-	DomainsCertificate DomainsCertificates
-	//ChallengeCerts     map[string]*ChallengeCert
-}
-
-// DomainsCertificates stores a certificate for multiple domains
-type DomainsCertificates struct {
-	Certs []*DomainsCertificate
-}
-
-// DomainsCertificate contains a certificate for multiple domains
-type DomainsCertificate struct {
-	Domains     Domain
-	Certificate *Certificate
-	//tlsCert     *tls.Certificate
-}
-
 // Domain holds a domain name with SANs
 type Domain struct {
 	Main string
@@ -29,9 +8,12 @@ type Domain struct {
 
 // Certificate is used to store certificate info
 type Certificate struct {
-	Domain        string
-	CertURL       string
-	CertStableURL string
-	PrivateKey    []byte
+	Domain        Domain
 	Certificate   []byte
+	Key           []byte
+}
+
+// Certificates holds one or more certificates
+type Certificates struct {
+	Certificates []*Certificate
 }

--- a/traefik-certificate-extractor.go
+++ b/traefik-certificate-extractor.go
@@ -1,13 +1,13 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
-	"os"
-	"strings"
 	"io/ioutil"
-	"encoding/json"
+	"os"
 	"path"
+	"strings"
 
 	"github.com/fsnotify/fsnotify"
 	"path/filepath"
@@ -26,14 +26,14 @@ func main() {
 	watch := flag.Bool("watch", false, "should the extractor-tool keep watching the acme.json-file and rewrite the certificates")
 	flag.Parse()
 
-	if (*acme_json_file == "" || *target_dir == "") {
+	if *acme_json_file == "" || *target_dir == "" {
 		fmt.Print("you must specify -acmejson and -target\n")
 		os.Exit(1)
 	}
 
 	extract_certs_from_acme_json(*acme_json_file, *target_dir)
 
-	if (*watch) {
+	if *watch {
 		watch_and_extract_certs_from_acme_json(*acme_json_file, *target_dir)
 	}
 }
@@ -58,15 +58,15 @@ func watch_and_extract_certs_from_acme_json(acme_json_file string, target_dir st
 				changed_file_abs, err := filepath.Abs(event.Name)
 				check(err)
 
-				if (acme_json_file_abs != changed_file_abs) {
+				if acme_json_file_abs != changed_file_abs {
 					continue
 				}
 
-				if (event.Op & fsnotify.Write == fsnotify.Write) || (event.Op & fsnotify.Create == fsnotify.Create) {
+				if (event.Op&fsnotify.Write == fsnotify.Write) || (event.Op&fsnotify.Create == fsnotify.Create) {
 					if timer != nil {
 						timer.Stop()
 					}
-					timer = time.AfterFunc(time.Second * 1, func() {
+					timer = time.AfterFunc(time.Second*1, func() {
 						update_extract <- true
 					})
 				}
@@ -90,13 +90,13 @@ func extract_certs_from_acme_json(acme_json_file string, target_dir string) {
 	certificates := unmarshal_acme_json(acme_json_file)
 
 	for _, cert := range certificates.Certificates {
-		var err error;
+		var err error
 
 		fmt.Printf("%s\n", format_domain_name(cert.Domain))
 
 		cert_target_dir := path.Join(target_dir, cert.Domain.Main)
 
-		err = os.MkdirAll(cert_target_dir, 0700);
+		err = os.MkdirAll(cert_target_dir, 0700)
 		check(err)
 
 		extract_cert(cert, cert_target_dir)
@@ -118,11 +118,11 @@ func extract_cert(certificate *Certificate, target_dir string) {
 
 func format_domain_name(domain Domain) string {
 	sans := ""
-	if (len(domain.SANs) > 0) {
+	if len(domain.SANs) > 0 {
 		sans = " (" + strings.Join(domain.SANs, ", ") + ")"
 	}
 
-	return domain.Main + sans;
+	return domain.Main + sans
 }
 
 func unmarshal_acme_json(acmejsonfile string) Certificates {


### PR DESCRIPTION
The biggest change is the support for the new træfik `acme.json` format. The new format does no longer include an `url` parameter, so I removed it.

I also implemented a multi-stage build in the Dockerfile to allow automated builds with docker hub. Because of this, I removed the `push` target in the Makefile (when an automated build is set up, this should no longer be needed).

The other commits should be self-explanatory.